### PR TITLE
Misc: Django 5.2 upgrade

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -62,22 +62,24 @@ jobs:
       matrix:
         python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         # build LTS version, next version, HEAD
-        django: ["32", "42", "50", "main"]
+        django: ["42", "50", "52", "main"]
         exclude:
           - python: "3.8"
             django: "50"
           - python: "3.8"
+            django: "52"
+          - python: "3.8"
             django: "main"
           - python: "3.9"
             django: "50"
+          - python: "3.9"
+            django: "52"
           - python: "3.9"
             django: "main"
           - python: "3.10"
             django: "main"
           - python: "3.11"
-            django: "32"
-          - python: "3.12"
-            django: "32"
+            django: "main"
 
     env:
       TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
     rev: "v0.1.5"
     hooks:
       - id: ruff
+        name: ruff check
         args: [--fix, --exit-non-zero-on-fix]
 
   # python static type checking

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+# v0.5
+
+- Adds Django 5.2 support
+- Drops support for Django versions before 4.2 (3.2, 4.0, 4.1)
+- Updates test workflows to ensure Django main branch is only tested with Python 3.12
+- Updates ruff command to use modern "ruff check" syntax
+- Applies code formatting with black and ruff
+
 # v0.4
 
 - Adds Django 5.0 to build matrix

--- a/charidfield/__init__.py
+++ b/charidfield/__init__.py
@@ -3,7 +3,7 @@ from .fields import CharIDField
 __all__ = ["CharIDField"]
 
 __title__ = "django-charid-field"
-__version__ = "0.2.2"
+__version__ = "0.5"
 __author__ = "YunoJuno"
 __license__ = "MIT License"
 __copyright__ = "Copyright YunoJuno"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-charid-field"
-version = "0.4"
+version = "0.5"
 description = "Provides a char-based, prefixable ID field for your Django models. Supports cuid, ksuid, ulid, et al."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -10,11 +10,9 @@ repository = "https://github.com/yunojuno/django-charid-field"
 documentation = "https://github.com/yunojuno/django-charid-field/blob/master/README"
 classifiers = [
     "Environment :: Web Environment",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.2",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
@@ -28,7 +26,7 @@ packages = [{ include = "charidfield" }]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-django = "^3.2 || ^4.0 || ^5.0"
+django = "^4.2 || ^5.0"
 
 [tool.poetry.group.test.dependencies]
 coverage = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,10 @@ envlist =
     fmt, lint, mypy,
     django-checks,
     ; https://docs.djangoproject.com/en/5.0/releases/
-    django32-py{38,39,310}
-    django40-py{38,39,310}
-    django41-py{38,39,310,311}
     django42-py{38,39,310,311}
     django50-py{310,311,312}
-    djangomain-py{311,312}
+    django52-py{310,311,312}
+    djangomain-py312
 
 [testenv]
 deps =
@@ -17,11 +15,9 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
-    django50: https://github.com/django/django/archive/stable/5.0.x.tar.gz
+    django50: Django>=5.0,<5.1
+    django52: Django>=5.2,<5.3
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =
@@ -48,7 +44,7 @@ deps =
     ruff
 
 commands =
-    ruff charidfield
+    ruff check charidfield
 
 [testenv:mypy]
 description = Python source code type hints (mypy)


### PR DESCRIPTION
# Django 5.2 Compatibility Update

This PR introduces compatibility for Django 5.2 and makes several maintenance improvements to the project.

## Changes

1. Dependency Updates
2. Added support for Django 5.2
3. Dropped support for Django versions before 4.2 (3.2, 4.0, 4.1)
4. Updated dependency specifiers in pyproject.toml

## Testing and CI Improvements

1. Updated tox.ini to test against Django 4.2, 5.0, 5.2, and main
2. Modified GitHub Action workflow to only test Django main branch on Python 3.12
3. Adjusted Python/Django compatibility matrix

## Code Quality

1. Updated ruff commands to use the modern "ruff check" syntax
2. Ran code formatting tools (black and ruff) on the codebase

## Documentation

1. Updated CHANGELOG with version 0.5 details
2. Updated supported Django versions in project metadata

## Versioning
Bumped project version to 0.5